### PR TITLE
drop suppurt python 3.8 and add 3.12

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 15
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache License"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 pydantic = "^2.4.2"
 requests = "^2.31.0"
 click = "^8.1.7"

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,17 @@
 [tox]
 isolated_build = true
 envlist =
-    py38
     py39
     py310
     py311
+    py312
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv]
 skip_install = true


### PR DESCRIPTION
## 変更内容
Python 3.8 のサポートを削除、Python 3.12 のサポートを追加
[sphinx](https://pypi.org/project/Sphinx/)がpython 3.9以降なため