### PR TITLE
コマンド全体でエラーハンドリングするように変更

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ click = "^8.1.7"
 pydantic-settings = "^2.1.0"
 
 [tool.poetry.scripts]
-vpsc = "vpsc.commands:vpsc"
+vpsc = "vpsc.commands:entry_point"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.10.1"

--- a/vpsc/api_request.py
+++ b/vpsc/api_request.py
@@ -4,13 +4,14 @@ APIへのリクエストを直接的に行なっているモジュールです�
 ページングなどの処理もこちらで対応。
 
 """
-import json
 from collections.abc import Sized, Iterator
 from types import MappingProxyType
 from typing import Literal, Optional, Type, TYPE_CHECKING
 
 import requests
 from pydantic import BaseModel
+
+from .exceptions import APIException
 
 if TYPE_CHECKING:
     from client import APIConfig
@@ -90,7 +91,8 @@ class APIRequest(Iterator, Sized):
 
     def _fetch(self, **req_data) -> Optional[dict]:
         res = requests.request(**req_data)
-        res.raise_for_status()
+        if 400 <= res.status_code < 600:
+            raise APIException(res.status_code, res.json())
         if res.content is not None and len(res.content) > 3:
             data = res.json()
             self.count = data.get("count", 1)

--- a/vpsc/commands.py
+++ b/vpsc/commands.py
@@ -7,6 +7,7 @@ from time import sleep
 
 import click
 
+from .exceptions import exception_handler, APIException
 from .models import UpdateServer, UpdateHost, UpdateNfsServer, UpdateNfsServerIpv4
 from .client import APIConfig, Client
 
@@ -100,7 +101,7 @@ def update_server_ptr_record(server_id, _type, hostname):
 
 
 @click.command(name="list")
-@click.option("--nfs-server-id", "-nid", help="NFSサーバーID", required=False, type=int)
+@click.option("--nfs-server-id", "-id", help="NFSサーバーID", required=False, type=int)
 def get_nfs_servers(server_id):
     """NFSサーバー情報の取得"""
     if server_id is not None:
@@ -111,7 +112,7 @@ def get_nfs_servers(server_id):
 
 
 @click.command(name="update")
-@click.option("--nfs-server-id", "-nid", help="NFSサーバーID", required=False, type=int)
+@click.option("--nfs-server-id", "-id", help="NFSサーバーID", required=False, type=int)
 @click.option("--name", "-n", help="名前", required=False, type=str, default="")
 @click.option("--description", "-d", help="説明", required=False, type=str, default="")
 def update_nfs_server(nfs_server_id, name, description):
@@ -122,7 +123,7 @@ def update_nfs_server(nfs_server_id, name, description):
 
 
 @click.command(name="update-ipv4")
-@click.option("--nfs-server-id", "-nid", help="NFSサーバーID", required=False, type=int)
+@click.option("--nfs-server-id", "-id", help="NFSサーバーID", required=False, type=int)
 @click.option("--hostname", "-h", help="ホスト名", required=True, type=str)
 def update_nfs_server_ipv4(nfs_server_id, address, netmask):
     """NFSサーバーのipv4を設定"""
@@ -151,3 +152,12 @@ nfs_server.add_command(get_nfs_servers)
 nfs_server.add_command(update_nfs_server)
 nfs_server.add_command(update_nfs_server_ipv4)
 nfs_server.add_command(get_nfs_server_power_status)
+
+
+def entry_point():
+    try:
+        vpsc()
+    except APIException as e:
+        exception_handler(e)
+    except Exception as e:
+        click.echo(e)

--- a/vpsc/exceptions.py
+++ b/vpsc/exceptions.py
@@ -1,0 +1,13 @@
+class APIException(Exception):
+    def __init__(self, status, json):
+        self.status = status
+        self.json = json
+
+
+def exception_handler(exc):
+    if isinstance(exc, APIException):
+        if exc.status == 404:
+            print(f"error_code：{exc.json['code']}\nmessage:{exc.json['message'] }")
+        else:
+            print(f"status_code: {exc.status}")
+            print(f"content: {exc.json}")


### PR DESCRIPTION
## 変更点
現状リクエストのエラーがそのまま出力されていました。  
そのため、エラーハンドリングできるよう設計を調整しました。

## その他の変更
nfsのid指定がidとnidの2パターンあったため、idに統一しました。

## 関連issue
